### PR TITLE
Add import of zfa.owl

### DIFF
--- a/vertebrate.owl
+++ b/vertebrate.owl
@@ -26,6 +26,8 @@
         <owl:imports rdf:resource="&obo;upheno/imports/uberon_import.owl"/>
         <owl:imports rdf:resource="&obo;vt.owl"/>
         <owl:imports rdf:resource="&obo;upheno/zp.owl"/>
+        <owl:imports rdf:resource="&obo;zfa.owl"/>
+
     </owl:Ontology>
     
 


### PR DESCRIPTION
UBERON does not handle all ZFA classes that are used in [zp.owl](http://purl.obolibrary.org/obo/upheno/zp.owl). One way to solve this very fast, would be to simply import the whole zfa. Depends on how fast we want to resolve the problems with zp in monarch.owl ...