### PR TITLE
Updated patterns to use CURIE prefixes

### DIFF
--- a/src/patterns/Makefile
+++ b/src/patterns/Makefile
@@ -26,5 +26,4 @@ $(MP):
 	curl -L -O http://purl.obolibrary.org/obo/mp.owl
 
 $(pattern-files): $(HP) $(MP)
-	dosdp-scala --ontology=$(MP) --reasoner=elk --template=$@ --outfile=$(basename $@).mp.tsv; dosdp-scala --ontology=$(HP) --reasoner=elk --template=$@ --outfile=$(basename $@).hp.tsv
-
+	dosdp-scala --ontology=$(MP) --reasoner=elk --obo-prefixes=true --template=$@ --outfile=$(basename $@).mp.tsv; dosdp-scala --ontology=$(HP) --reasoner=elk --obo-prefixes=true --template=$@ --outfile=$(basename $@).hp.tsv

--- a/src/patterns/abnormal.yaml
+++ b/src/patterns/abnormal.yaml
@@ -1,15 +1,15 @@
 pattern_name: abnormal
 
 classes:
-  quality: PATO_0000001
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  quality: PATO:0000001
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: Thing

--- a/src/patterns/abnormalLevel.yaml
+++ b/src/patterns/abnormalLevel.yaml
@@ -1,14 +1,14 @@
 pattern_name: abnormalNumber
 
 classes:
-  amount: PATO_0000070
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  amount: PATO:0000070
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/abnormalSize.yaml
+++ b/src/patterns/abnormalSize.yaml
@@ -1,15 +1,15 @@
 pattern_name: abnormalSize
 
 classes:
-  size: PATO_0000117
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  size: PATO:0000117
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/abnormalWeight.yaml
+++ b/src/patterns/abnormalWeight.yaml
@@ -1,15 +1,15 @@
 pattern_name: abnormalWeight
 
 classes:
-  weight: PATO_0000128
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  weight: PATO:0000128
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/absent.yaml
+++ b/src/patterns/absent.yaml
@@ -1,15 +1,15 @@
 pattern_name: absent
 
 classes:
-  absent: PATO_0000462
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  absent: PATO:0000462
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/atresia.yaml
+++ b/src/patterns/atresia.yaml
@@ -1,15 +1,15 @@
 pattern_name: atresia
 
 classes:
-  atretic: PATO_0001819
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  atretic: PATO:0001819
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/atrophy.yaml
+++ b/src/patterns/atrophy.yaml
@@ -1,15 +1,15 @@
 pattern_name: atrophy
 
 classes:
-  atrophied: PATO_0001623
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  atrophied: PATO:0001623
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/calcified.yaml
+++ b/src/patterns/calcified.yaml
@@ -1,15 +1,15 @@
 pattern_name: calcified
 
 classes:
-  calcified: PATO_0001447
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  calcified: PATO:0001447
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/decreasedLevel.yaml
+++ b/src/patterns/decreasedLevel.yaml
@@ -1,15 +1,15 @@
 pattern_name: decreasedLevel
 
 classes:
-  decreased amount: PATO_0001997
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  decreased amount: PATO:0001997
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/decreasedSize.yaml
+++ b/src/patterns/decreasedSize.yaml
@@ -1,15 +1,15 @@
 pattern_name: decreasedSize
 
 classes:
-  decreased size: PATO_0000587
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  decreased size: PATO:0000587
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/decreasedWeight.yaml
+++ b/src/patterns/decreasedWeight.yaml
@@ -1,15 +1,15 @@
 pattern_name: decreasedWeight
 
 classes:
-  decreased weight: PATO_0000583
-  abnormal: PATO_0000460
+  decreased weight: PATO:0000583
+  abnormal: PATO:0000460
   Thing: http://www.w3.org/2002/07/owl#Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/degeneration.yaml
+++ b/src/patterns/degeneration.yaml
@@ -1,15 +1,15 @@
 pattern_name: degeneration
 
 classes:
-  degenerate: PATO_0000639
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  degenerate: PATO:0000639
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/delayedProcess.yaml
+++ b/src/patterns/delayedProcess.yaml
@@ -1,15 +1,15 @@
 pattern_name: delayedProcess
 
 classes:
-  delayed: PATO_0000502
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  delayed: PATO:0000502
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/increasedLevel.yaml
+++ b/src/patterns/increasedLevel.yaml
@@ -1,15 +1,15 @@
 pattern_name: increasedLevel
 
 classes:
-  increased amount: PATO_0000470
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  increased amount: PATO:0000470
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/increasedSize.yaml
+++ b/src/patterns/increasedSize.yaml
@@ -1,15 +1,15 @@
 pattern_name: increasedSize
 
 classes:
-  increased size: PATO_0000586
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  increased size: PATO:0000586
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/increasedWeight.yaml
+++ b/src/patterns/increasedWeight.yaml
@@ -1,15 +1,15 @@
 pattern_name: increasedWeight
 
 classes:
-  increased weight: PATO_0000582
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  increased weight: PATO:0000582
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/missingProcess.yaml
+++ b/src/patterns/missingProcess.yaml
@@ -1,15 +1,15 @@
 pattern_name: missingProcess
 
 classes:
-  lacking processual parts: PATO_0001558
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  lacking processual parts: PATO:0001558
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"

--- a/src/patterns/morphology.yaml
+++ b/src/patterns/morphology.yaml
@@ -1,15 +1,15 @@
 pattern_name: morphology
 
 classes:
-  morphology: PATO_0000051
-  abnormal: PATO_0000460
-  Thing: http://www.w3.org/2002/07/owl#Thing
+  morphology: PATO:0000051
+  abnormal: PATO:0000460
+  Thing: owl:Thing
 
 relations: 
-  inheres_in: RO_0000052
-  qualifier: RO_0002573
-  has_part: BFO_0000051
-  has_part: BFO_0000051
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  has_part: BFO:0000051
 
 vars:
   entity: "Thing"


### PR DESCRIPTION
dosdp-scala now supports prefix expansion with built-in support for automatic OBO-style expansion.