### PR TITLE
adding abnormalShapeByType.yaml

### DIFF
--- a/src/patterns/abnormalShapeByType.yaml
+++ b/src/patterns/abnormalShapeByType.yaml
@@ -1,10 +1,11 @@
 pattern_name: abnormalShapeByType 
 pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns/abnormalShapeByType
+description: "anatomical enity with an abnormal shape of a specified shape. i.e.,columnar shaped head"
 
 classes:
   shape: PATO:0000052
   abnormal: PATO:0000460
-  entity: BFO:0000001
+  entity: UBERON:0001062 
 
 relations: 
   inheres_in: RO:0000052
@@ -19,7 +20,7 @@ vars:
   shape: "'shape'"
 
 name:
-  text: "abnormal %s shape of %s "
+  text: "%s %s"
   vars:
    - shape
    - entity

--- a/src/patterns/abnormalShapeByType.yaml
+++ b/src/patterns/abnormalShapeByType.yaml
@@ -1,0 +1,45 @@
+pattern_name: abnormalShapeByType 
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns/abnormalShapeByType
+
+classes:
+  shape: PATO:0000052
+  abnormal: PATO:0000460
+  entity: BFO:0000001
+
+relations: 
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym 
+
+vars:
+  entity: "'entity'"
+  shape: "'shape'"
+
+name:
+  text: "abnormal %s shape of %s "
+  vars:
+   - shape
+   - entity
+
+annotations:
+  - 
+    annotationProperty: exact_synonym
+    text: "abnormal %s shape of %s"
+    vars:
+     - shape
+     - entity
+
+def:
+  text: "Any structural anomaly that causes %s to be %s shaped."
+  vars:
+    - entity
+    - shape
+
+equivalentTo:
+  text: "'has_part' some (%s and ('inheres_in' some %s) and ('qualifier' some 'abnormal'))"
+  vars:
+    - shape
+    - entity


### PR DESCRIPTION
Hello. 

I have a pattern that I would like to be reviewed and hopefully added to upheno. It enables two variables to be used, 1) the shape and 2) the entity. This way many shapes can be used with this same pattern. The alternative is to create a new pattern for every shape.

```
"'has_part' some (%s and ('inheres_in' some %s) and ('qualifier' some 'abnormal'))"
```

Thank you,
Sofia


