### PR TITLE
Abnormal number of anatomy by type

### DIFF
--- a/src/patterns/abnormalNumberOfAnatomyByType.yaml
+++ b/src/patterns/abnormalNumberOfAnatomyByType.yaml
@@ -1,0 +1,46 @@
+pattern_name: abnormalNumberOfAnatomyByType 
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns/abnormalNumberOfAnatomyByType.yaml
+description: "this pattern is used to describe phenotypes in which there is an abnormal number of anatomical enities. Examples of quantity terms that are appropriate are 'altered number of','has fewer parts of type', 'has extra parts of type', 'lacks all parts of type'. For example, has extra parts of type head." 
+
+classes:
+  quantity: PATO:0001555
+  abnormal: PATO:0000460
+  entity: UBERON:0001062 
+
+relations: 
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym 
+
+vars:
+  entity: "'entity'"
+  quantity: "'quantity'"
+
+name:
+  text: "%s %s"
+  vars:
+   - quantity
+   - entity
+
+annotations:
+  - 
+    annotationProperty: exact_synonym
+    text: "%s %s"
+    vars:
+     - quantity
+     - entity
+
+def:
+  text: "Any structural anomaly that causes there to be %s %s."
+  vars:
+    - quantity
+    - entity
+
+equivalentTo:
+  text: "'has_part' some (%s and ('inheres_in' some %s) and ('qualifier' some 'abnormal'))"
+  vars:
+    - quantity
+    - entity

--- a/src/patterns/lesionInLocationByShape.yaml
+++ b/src/patterns/lesionInLocationByShape.yaml
@@ -1,0 +1,40 @@
+pattern_name: lesionInLocationByShape
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns/lesionInLocationByShape
+
+classes:
+  shape: PATO:0000052
+  abnormal: PATO:0000460
+  entity: BFO:0000001
+  lesion: NCIT:C3824
+
+relations:
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  part_of: BFO:0000050
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+
+vars:
+  entity: "'entity'"
+  shape: "'shape'"
+
+ 
+name:
+  text: "abnormal %s with %s lesion"
+  vars:
+   - entity
+   - shape
+
+def:
+  text: "An abnormal %s with %s lesion."
+  vars:
+    - entity
+    - shape
+
+equivalentTo:
+  text: "'has_part' some (%s and ('inheres_in' some ('lesion' and ('part_of' some %s))) and ('qualifier' some 'abnormal'))"
+  vars:
+    - shape
+    - entity


### PR DESCRIPTION
This pattern is used in PLANP to describe phenotypes in which there is an abnormal number of anatomical entities. Examples of 'quantity' terms that are appropriate are 
  - 'altered number of',
  - 'has fewer parts of type', 
  - 'has extra parts of type', 
  - 'lacks all parts of type'. 

For example, 
  - 'has altered number of' 'head'.
  - 'has extra parts of type' 'head'.
  - 'has extra parts of type' 'pharynx'
  - 'has extra parts of type' 'tail'
  - 'has fewer parts of type' 'eye'
  - 'lacks all parts of type' 'eye'
