### PR TITLE
Updated abnormalAnatomicalEntity to inheres in part of

### DIFF
--- a/src/patterns/dosdp-patterns/abnormalAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-patterns/abnormalAnatomicalEntity.yaml
@@ -18,7 +18,7 @@ classes:
   anatomical entity: UBERON:0001062
 
 relations: 
-  inheres_in: RO:0000052
+  inheres_in_part_of: RO:0002314
   has_modifier: RO:0002573
   has_part: BFO:0000051
   
@@ -45,6 +45,6 @@ def:
     - anatomical_entity
 
 equivalentTo:
-  text: "'has_part' some ('quality' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
+  text: "'has_part' some ('quality' and ('inheres_in_part_of' some %s) and ('has_modifier' some 'abnormal'))"
   vars:
     - anatomical_entity


### PR DESCRIPTION
In accordance with our last meeting on the issue (3 weeks ago), I changed the relation of the abnormal anatomical entity pattern from inheres in to inheres in part of for this pattern, and this pattern only. This means that from now on, an abnormality of a neuron constitutes an abnormality of the brain!

Please sign off @sbello @ybradford @drseb 

If we find in the next months we need to reflect exceptions to this rule, we will create a new pattern for that.