### PR TITLE
example usage of data_var in pattern

### DIFF
--- a/src/patterns/dosdp-dev/abnormalDistanceBetweenAnatomicalEntities.yaml
+++ b/src/patterns/dosdp-dev/abnormalDistanceBetweenAnatomicalEntities.yaml
@@ -26,31 +26,31 @@ vars:
   anatomical_entity1: "'anatomical_entity1'"
   anatomical_entity2: "'anatomical_entity2'"
 
+data_list_vars:
+  def_dbxrefs: xsd:string
+  exact_syns: xsd:string
+
 name:
   text: "abnormal distance between %s and %s"
   vars:
    - anatomical_entity1
    - anatomical_entity2
 
-annotations:
-  - 
-    annotationProperty: exact_synonym
-    text: "abnormal distance between %s and %s"
-    vars:
-     - anatomical_entity1
-     - anatomical_entity2
-  - 
-    annotationProperty: exact_synonym
-    text: "distance abnormal between %s and %s"
+generated_synonyms:
+  - text: "distance abnormal between %s and %s"
     vars:
      - anatomical_entity1
      - anatomical_entity2
 
+exact_synonym:
+    value: exact_syns
+    
 def:
   text: "abnormal distance between %s and %s."
   vars:
     - anatomical_entity1
     - anatomical_entity2
+  xrefs: def_dbxrefs
 
 equivalentTo:
   text: "'has_part' some ('distance' and ('inheres_in' some (%s and ('towards' some %s))) and ('has_modifier' some 'abnormal'))"


### PR DESCRIPTION
changed
 - added data_var exact_syns
 - added data_var def_xrefs
 - generated synonymns
 - removed exact synonyms in the annotations block

Example TSV
                       
| defined_class | defined_class_name | anatomical_entity1 | anatomical_entity1_label | anatomical_entity2 | anatomical_entity2_label | exact_syns          | def_dbxrefs                    | defined_class_exact_synonym                | 
|---------------|--------------------|--------------------|--------------------------|--------------------|--------------------------|---------------------|--------------------------------|--------------------------------------------| 
| PLANA:1000032 |                    | PLANA:0000030      | midline                  | PLANA:0000030      | midline                  | syn1 \| syn2 \|  syn3 | PMID:0000000 \| UBERON:00000000 | test overwrite defined_class_exact_synonym | 
