### PR TITLE
Update and rename malformedAnatomicalEntity.yaml to malformedSubtypeO…

### DIFF
--- a/src/patterns/dosdp-dev/abnormallyMalformedAnatomicalEntityByType.yaml
+++ b/src/patterns/dosdp-dev/abnormallyMalformedAnatomicalEntityByType.yaml
@@ -1,5 +1,5 @@
-pattern_name: malformedSubtypeOfAnatomicalEntity
-pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/malformedSubTypeOfAnatomicalEntity.yaml
+pattern_name: abnormallyMalformedAnatomicalEntityByType
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/abnormallyMalformedAnatomicalEntityByType.yaml
 Description: A malformed subtype of an anatomical entity, such as a wholly dorsalized embryo. This pattern can use any subclass of PATO malformed.
 
 contributors:

--- a/src/patterns/dosdp-dev/malformedSubtypeOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/malformedSubtypeOfAnatomicalEntity.yaml
@@ -1,0 +1,38 @@
+pattern_name: malformedSubtypeOfAnatomicalEntity
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/malformedSubTypeOfAnatomicalEntity.yaml
+Description: A malformed subtype of an anatomical entity, such as a wholly dorsalized embryo. This pattern can use any subclass of PATO malformed.
+
+contributors:
+  - https://orcid.org/0000-0001-5208-3432
+
+classes:
+  malformed: PATO:0000646
+  abnormal: PATO:0000460
+  anatomical entity: UBERON:0001062
+
+relations:
+  inheres_in: RO:0000052
+  has_modifier: RO:0002573
+  has_part: BFO:0000051
+
+vars:
+  malformed: "'malformed'"
+  natomical_entity: "'anatomical entity'"
+
+name:
+  text: "%s %s"
+  vars:
+   - malformed
+   - anatomical_entity
+
+def:
+  text: "A %s %s."
+  vars:
+   - malformed
+   - anatomical_entity
+
+equivalentTo:
+text: "'has_part' some ('%s' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
+vars:
+  - malformed
+  - anatomical_entity


### PR DESCRIPTION
…fAnatomicalEntity.yaml

addresses #538 
note - there is already a pattern called malformedAnatomicalEntity, that uses PATO malformed. Alternatively, we could just update that pattern to make malformed a variable?
https://github.com/obophenotype/upheno/blob/master/src/patterns/dosdp-dev/malformedAnatomicalEntity.yaml