### PR TITLE
Add increased biological process quality patterns

### DIFF
--- a/src/patterns/dosdp-dev/abnormallyIncreasedQualityOfBiologicalProcess.yaml
+++ b/src/patterns/dosdp-dev/abnormallyIncreasedQualityOfBiologicalProcess.yaml
@@ -1,0 +1,37 @@
+pattern_name: abnormallyIncreasedQualityOfBiologicalProcess
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/abnormallyIncreasedQualityOfBiologicalProcess.yaml
+description: "Process that appears in some (unspecified) way strengthened or increased (more frequent, more strong)."
+
+contributors:
+  - https://orcid.org/0000-0001-7487-610X
+
+classes:
+  increased process quality: PATO:0002304
+  abnormal: PATO:0000460
+  biological process: GO:0008150
+
+relations: 
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym 
+
+vars:
+  biological_process: "'biological process'"
+ 
+name:
+  text: "increased qualitatively %s"
+  vars:
+   - biological_process
+
+def:
+  text: "Increased qualitatively %s."
+  vars:
+    - biological_process
+
+equivalentTo:
+  text: "'has_part' some ('increased process quality' and ('inheres_in' some %s) and ('qualifier' some 'abnormal'))"
+  vars:
+    - biological_process

--- a/src/patterns/dosdp-dev/abnormallyIncreasedQualityOfBiologicalProcessInLocation.yaml
+++ b/src/patterns/dosdp-dev/abnormallyIncreasedQualityOfBiologicalProcessInLocation.yaml
@@ -1,0 +1,43 @@
+pattern_name: abnormallyIncreasedQualityOfBiologicalProcessInLocation
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/abnormallyIncreasedQualityOfBiologicalProcessInLocation.yaml
+description: "Process in a location that appears in some (unspecified) way strengthened or increased (more frequent, more strong)."
+
+contributors:
+  - https://orcid.org/0000-0001-7487-610X
+
+classes:
+  increased process quality: PATO:0002304
+  abnormal: PATO:0000460
+  biological process: GO:0008150
+  independent continuant: BFO:0000004
+
+relations: 
+  inheres_in: RO:0000052
+  qualifier: RO:0002573
+  has_part: BFO:0000051
+  occurs_in: BFO:0000066
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym 
+
+vars:
+  biological_process: "'biological process'"
+  location: "'independent continuant'"
+ 
+name:
+  text: "increased qualitatively %s in %s"
+  vars:
+   - biological_process
+   - location
+
+def:
+  text: "Increased qualitatively %s in %s."
+  vars:
+    - biological_process
+    - location
+
+equivalentTo:
+  text: "'has_part' some ('increased process quality' and ('inheres_in' some (%s and ('occurs_in' some %s))) and ('qualifier' some 'abnormal'))"
+  vars:
+    - biological_process
+    - location


### PR DESCRIPTION
It seems that the patterns 'abnormally decreased quality of biological process' and 'abnormally decreased quality of biological process in location' don't have any corresponding patterns for when the quality is increased. This pull request adds two new patterns to fix both cases.

@matentzn I can't remember if you requested adding 'abnormally increased quality of biological process _in location_', I only included it because the decreased case already existed.