### PR TITLE
Remove whitespace

### DIFF
--- a/src/patterns/dosdp-dev/abnormalCoilingOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormalCoilingOfAnatomicalEntity.yaml
@@ -22,7 +22,7 @@ vars:
   anatomical_entity: "'anatomical entity'"
 
 name:
-  text: "abnormally coiled %s "
+  text: "abnormally coiled %s"
   vars:
   - anatomical_entity
 
@@ -41,4 +41,3 @@ equivalentTo:
   text: "'has_part' some ('coiled' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
   vars:
   - anatomical_entity
-

--- a/src/patterns/dosdp-dev/abnormallyBentAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyBentAnatomicalEntity.yaml
@@ -19,7 +19,7 @@ vars:
   anatomical_entity: "'anatomical entity'"
 
 name:
-  text: "abnormal bending of %s "
+  text: "abnormal bending of %s"
   vars:
   - anatomical_entity
 

--- a/src/patterns/dosdp-dev/abnormallyBentAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyBentAnatomicalEntity.yaml
@@ -25,10 +25,6 @@ name:
 
 annotations:
 - annotationProperty: exact_synonym
-  text: "abnormal bending of %s"
-  vars:
-  - anatomical_entity
-- annotationProperty: exact_synonym
   text: "abnormally bending %s"
   vars:
   - anatomical_entity

--- a/src/patterns/dosdp-dev/abnormallyCurvedAnatomicalEntityByOrientation.yaml
+++ b/src/patterns/dosdp-dev/abnormallyCurvedAnatomicalEntityByOrientation.yaml
@@ -11,20 +11,20 @@ classes:
   abnormal: PATO:0000460
   anatomical entity: UBERON:0001062
 
-relations: 
+relations:
   inheres_in: RO:0000052
   has_modifier: RO:0002573
   has_part: BFO:0000051
 
 annotationProperties:
-  exact_synonym: oio:hasExactSynonym 
+  exact_synonym: oio:hasExactSynonym
 
 vars:
   anatomical_entity: "'anatomical entity'"
   orientation: "'curved'"
 
 name:
-  text: "abnormal %s, %s "
+  text: "abnormal %s, %s"
   vars:
    - anatomical_entity
    - orientation
@@ -34,7 +34,7 @@ annotations:
     text: "%s %s"
     vars:
      - orientation
-     - anatomical_entity 
+     - anatomical_entity
 
 def:
   text: "Any abnormal %s that is %sly."

--- a/src/patterns/dosdp-dev/abnormallyDecreasedCoilingOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyDecreasedCoilingOfAnatomicalEntity.yaml
@@ -22,7 +22,7 @@ vars:
   anatomical_entity: "'anatomical entity'"
 
 name:
-  text: "abnormally decreased coiling of %s "
+  text: "abnormally decreased coiling of %s"
   vars:
   - anatomical_entity
 
@@ -41,4 +41,3 @@ equivalentTo:
   text: "'has_part' some ('decreased coiling' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
   vars:
   - anatomical_entity
-

--- a/src/patterns/dosdp-dev/abnormallyIncreasedCoilingOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyIncreasedCoilingOfAnatomicalEntity.yaml
@@ -22,7 +22,7 @@ vars:
   anatomical_entity: "'anatomical entity'"
 
 name:
-  text: "abnormally increased coiling of %s "
+  text: "abnormally increased coiling of %s"
   vars:
   - anatomical_entity
 
@@ -41,4 +41,3 @@ equivalentTo:
   text: "'has_part' some ('increased coiling' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
   vars:
   - anatomical_entity
-


### PR DESCRIPTION
Fixes several patterns that introduce unwanted whitespace at the end of term labels. Also removes a redundant synonym from one of the patterns.