### PR TITLE
Model weight phenotypes as mass.

### DIFF
--- a/src/patterns/dosdp-dev/abnormalWeightOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormalWeightOfAnatomicalEntity.yaml
@@ -1,38 +1,39 @@
 pattern_name: abnormalWeightOfAnatomicalEntity
 pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/abnormalWeightOfAnatomicalEntity.yaml
-description: "NOTE: We are using mass, not weight, to model this phenotype, see also https://github.com/obophenotype/bio-attribute-ontology/issues/39"
+description: "An abnormality of the mass of an anatomical entity, e.g. increased or decreased mass of the whole organism. NOTE: We are using mass (PATO:0000125), not weight, to model this phenotype, see also https://github.com/obophenotype/bio-attribute-ontology/issues/39"
 
-contributors: 
+contributors:
   - https://orcid.org/0000-0002-3528-5267
   - https://orcid.org/0000-0001-5208-3432
-  
+  - https://orcid.org/0000-0002-9611-1279
+
 classes:
-  weight: PATO:0000125
+  mass: PATO:0000125
   abnormal: PATO:0000460
   anatomical entity: UBERON:0001062
 
-relations: 
+relations:
   inheres_in: RO:0000052
   has_modifier: RO:0002573
   has_part: BFO:0000051
 
 annotationProperties:
-  exact_synonym: oio:hasExactSynonym 
+  exact_synonym: oio:hasExactSynonym
 
 vars:
   anatomical_entity: "'anatomical entity'"
 
 name:
-  text: "abnormality of %s weight"
+  text: "abnormality of %s mass"
   vars:
    - anatomical_entity
 
 def:
-  text: "An abnormal increase or decrease of weight or an abnormal distribution of mass in the %s."
+  text: "An abnormality of mass in the %s."
   vars:
     - anatomical_entity
 
 equivalentTo:
-  text: "'has_part' some ('weight' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
+  text: "'has_part' some ('mass' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
   vars:
     - anatomical_entity

--- a/src/patterns/dosdp-dev/abnormallyDecreasedWeightOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyDecreasedWeightOfAnatomicalEntity.yaml
@@ -1,38 +1,49 @@
 pattern_name: abnormallyDecreasedWeightOfAnatomicalEntity
 pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/abnormallyDecreasedWeightOfAnatomicalEntity.yaml
-description: "Decreased weight/abnormally light particular anatomical entity. NOTE: We are using decreased mass (PATO:0001562), not weight, to model this phenotype, see also https://github.com/obophenotype/bio-attribute-ontology/issues/39"
+description: "Decreased mass of an anatomical entity, e.g. decreased mass of the whole organism. NOTE: We are using decreased mass (PATO:0001562), not weight, to model this phenotype, see also https://github.com/obophenotype/bio-attribute-ontology/issues/39"s
 
-contributors: 
+contributors:
   - https://orcid.org/0000-0002-3528-5267
   - https://orcid.org/0000-0001-5208-3432
+  - https://orcid.org/0000-0002-9611-1279
 
 classes:
-  decreased weight: PATO:0001562
+  decreased mass: PATO:0001562
   abnormal: PATO:0000460
   anatomical entity: UBERON:0001062
 
-relations: 
+relations:
   inheres_in: RO:0000052
   has_modifier: RO:0002573
   has_part: BFO:0000051
 
 annotationProperties:
-  exact_synonym: oio:hasExactSynonym 
+  exact_synonym: oio:hasExactSynonym
 
 vars:
   anatomical_entity: "'anatomical entity'"
 
 name:
-  text: "decreased %s weight"
+  text: "decreased %s mass"
   vars:
    - anatomical_entity
 
+annotations:
+  - annotationProperty: exact_synonym
+    text: "small %s mass"
+    vars:
+    - anatomical_entity
+  - annotationProperty: exact_synonym
+    text: "low %s mass"
+    vars:
+    - anatomical_entity
+
 def:
-  text: "An abnormal decrease in weight or a decreased distribution of mass in the %s."
+  text: "An abnormal decrease in mass in the %s."
   vars:
     - anatomical_entity
 
 equivalentTo:
-  text: "'has_part' some ('decreased weight' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
+  text: "'has_part' some ('decreased mass' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
   vars:
     - anatomical_entity

--- a/src/patterns/dosdp-dev/abnormallyIncreasedWeightOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyIncreasedWeightOfAnatomicalEntity.yaml
@@ -1,38 +1,49 @@
 pattern_name: abnormallyIncreasedWeightOfAnatomicalEntity
 pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/abnormallyIncreasedWeightOfAnatomicalEntity.yaml
-description: "Increase weight/abnormally heavy in a particular anatomical entity. Example: HP_0012743 'Abdominal obesity'. NOTE: We are using increased mass (PATO:0001563), not weight, to model this phenotype, see also https://github.com/obophenotype/bio-attribute-ontology/issues/39"
+description: "Increased mass of an anatomical entity, e.g. increased mass of the whole organism. NOTE: We are using increased mass (PATO:0001563), not weight, to model this phenotype, see also https://github.com/obophenotype/bio-attribute-ontology/issues/39"
 
-contributors: 
+contributors:
   - https://orcid.org/0000-0002-3528-5267
   - https://orcid.org/0000-0001-5208-3432
+  - https://orcid.org/0000-0002-9611-1279
 
 classes:
-  increased weight: PATO:0001563
+  increased mass: PATO:0001563
   abnormal: PATO:0000460
   anatomical entity: UBERON:0001062
 
-relations: 
+relations:
   inheres_in: RO:0000052
   has_modifier: RO:0002573
   has_part: BFO:0000051
 
 annotationProperties:
-  exact_synonym: oio:hasExactSynonym 
+  exact_synonym: oio:hasExactSynonym
 
 vars:
   anatomical_entity: "'anatomical entity'"
 
 name:
-  text: "increased %s weight"
+  text: "increased %s mass"
   vars:
    - anatomical_entity
 
+annotations:
+  - annotationProperty: exact_synonym
+    text: "large %s mass"
+    vars:
+    - anatomical_entity
+  - annotationProperty: exact_synonym
+    text: "high %s mass"
+    vars:
+    - anatomical_entity
+
 def:
-  text: "An abnormal increase in weight or an increased distribution of mass in the %s."
+  text: "An abnormal increase in mass in the %s."
   vars:
     - anatomical_entity
 
 equivalentTo:
-  text: "'has_part' some ('increased weight' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
+  text: "'has_part' some ('increased mass' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
   vars:
     - anatomical_entity


### PR DESCRIPTION
@matentzn I've made sure that 'weight' has been replaced with 'mass' throughout these patterns but without changing the pattern names as per https://github.com/obophenotype/upheno/pull/759.

I think these patterns should suffice for the term requests in https://github.com/obophenotype/xenopus-phenotype-ontology/issues/144.

Should we also add 'abnormal increased/decreased weight' as synonyms in these patterns?