### PR TITLE
Add premature closure anatomical entity template

### DIFF
--- a/src/patterns/dosdp-dev/prematureClosureOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/prematureClosureOfAnatomicalEntity.yaml
@@ -1,0 +1,53 @@
+pattern_name: prematureClosureOfAnatomicalEntity
+
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/prematureClosureOfAnatomicalEntity.yaml
+
+description: 'Premature closure of anatomical entity, e.g. premature cranial suture closure.'
+
+#  examples:
+#    - http://purl.obolibrary.org/obo/HP_0004440
+#    - http://purl.obolibrary.org/obo/MP_0030350
+#    - http://purl.obolibrary.org/obo/MP_0000081
+
+contributors:
+  - https://orcid.org/0000-0001-8314-2140
+
+classes:
+  premature_closure: PATO:0002166
+  abnormal: PATO:0000460
+  anatomical_entity: UBERON:0001062
+
+relations:
+  characteristic_of: RO:0000052
+  has_modifier: RO:0002573
+  has_part: BFO:0000051
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+
+vars:
+  anatomical_entity: "'anatomical_entity'"
+
+name:
+  text: "premature %s closure"
+  vars:
+    - anatomical_entity
+
+annotations:
+  - annotationProperty: exact_synonym
+    text: "premature closure of %s"
+    vars:
+      - anatomical_entity
+
+def:
+  text: "Premature closure of %s."
+  vars:
+    - anatomical_entity
+
+equivalentTo:
+  text: "'has_part' some (
+        'premature_closure' and
+        'characteristic_of' some %s and
+        'has_modifier' some 'abnormal')"
+  vars:
+    - anatomical_entity


### PR DESCRIPTION
This commit intends to add a new DOSDP pattern template
`prematureClosureOfAnatomicalEntity.yaml`.
If applied, this commit will fix #803.