### PR TITLE
Add non-functional anatomical entity template

### DIFF
--- a/src/patterns/dosdp-dev/non-functionalAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/non-functionalAnatomicalEntity.yaml
@@ -1,0 +1,64 @@
+---
+pattern_name: non-functionalAnatomicalEntity
+
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/non-functionalAnatomicalEntity.yaml
+
+description: 'Use this phenotype pattern when an anatomical entity is unable or completely fails to perform its regular function or functions. In cases of decreased functionality of the anatomical entity, consider the phenotype pattern "abnormallyDecreasedFunctionalityOfAnatomicalEntity.yaml".'
+
+#  examples:
+#    - http://purl.obolibrary.org/obo/ZP_0003641  # heart non-functional, abnormal
+#    - http://purl.obolibrary.org/obo/HP_0000083  # Renal insufficiency
+#    - http://purl.obolibrary.org/obo/MP_0003606  # kidney failure
+#    - http://purl.obolibrary.org/obo/HP_0001399  # Hepatic failure
+#    - http://purl.obolibrary.org/obo/MP_0003326  # liver failure
+
+contributors:
+  - https://orcid.org/0000-0001-8314-2140  # Ray Stefancsik
+
+classes:
+  non-functional: PATO:0001511
+  abnormal: PATO:0000460
+  anatomical_entity: UBERON:0001062
+
+relations:
+  characteristic_of: RO:0000052
+  has_modifier: RO:0002573
+  has_part: BFO:0000051
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  anatomical_entity: "'anatomical_entity'"
+
+name:
+  text: "non-functional %s"
+  vars:
+    - anatomical_entity
+
+annotations:
+  - annotationProperty: exact_synonym
+    text: "%s failure"
+    vars:
+      - anatomical_entity
+
+  - annotationProperty: related_synonym  # broad synonym?
+    text: "%s insufficiency"
+    vars:
+      - anatomical_entity
+
+def:
+  text: "Inability or failure of %s to perform its regular function or functions."
+  vars:
+    - anatomical_entity
+
+equivalentTo:
+  text: "'has_part' some (
+    'non-functional' and
+    ('characteristic_of' some %s) and
+    ('has_modifier' some 'abnormal')
+    )"
+  vars:
+    - anatomical_entity
+...


### PR DESCRIPTION
This commit intends to add a `non-functionalAnatomicalEntity.yaml` DOS-DP pattern draft for community review.
If applied, this commit will fix #844.