### PR TITLE
Fix capitalisation typo in increased ccc count pattern

### DIFF
--- a/src/patterns/dosdp-dev/abnormalFunctionalityOfPartOfAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormalFunctionalityOfPartOfAnatomicalEntity.yaml
@@ -27,7 +27,7 @@ name:
    - anatomical_entity
 
 def:
-  text: "Any functional anomaly of the %s."
+  text: "Any functional anomaly of the %s or one of its parts."
   vars:
     - anatomical_entity
 

--- a/src/patterns/dosdp-dev/abnormalResistanceOfWholeOrganismToEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormalResistanceOfWholeOrganismToEntity.yaml
@@ -8,7 +8,7 @@ contributors:
 classes:
   resistance to: PATO:0001178 
   abnormal: PATO:0000460
-  cellular organism: CARO:0010004
+  cellular organism: UBERON:0000468
   entity: BFO:0000001
 
 relations:

--- a/src/patterns/dosdp-dev/abnormallyDecreasedResistanceOfWholeOrganismToChemicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyDecreasedResistanceOfWholeOrganismToChemicalEntity.yaml
@@ -9,7 +9,7 @@ contributors:
 classes:
   decreased resistance to: PATO:0001651
   abnormal: PATO:0000460
-  cellular organism: CARO:0010004
+  cellular organism: UBERON:0000468
   chemical entity: CHEBI:24431
 
 relations:

--- a/src/patterns/dosdp-dev/abnormallyDecreasedResistanceOfWholeOrganismToEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyDecreasedResistanceOfWholeOrganismToEntity.yaml
@@ -8,7 +8,7 @@ contributors:
 classes:
   decreased resistance to: PATO:0001651
   abnormal: PATO:0000460
-  cellular organism: CARO:0010004
+  cellular organism: UBERON:0000468
   entity: BFO:0000001
 
 relations:

--- a/src/patterns/dosdp-dev/abnormallyIncreasedNumberOfCellularComponent.yaml
+++ b/src/patterns/dosdp-dev/abnormallyIncreasedNumberOfCellularComponent.yaml
@@ -24,7 +24,7 @@ vars:
   cellular_component: "'cellular component'"
 
 name:
-  text: "Increased number of %s"
+  text: "increased number of %s"
   vars:
    - cellular_component
 

--- a/src/patterns/dosdp-dev/abnormallyIncreasedResistanceOfWholeOrganismToChemicalEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyIncreasedResistanceOfWholeOrganismToChemicalEntity.yaml
@@ -9,7 +9,7 @@ contributors:
 classes:
   increased resistance to: PATO:0001650
   abnormal: PATO:0000460
-  cellular organism: CARO:0010004
+  cellular organism: UBERON:0000468
   chemical entity: CHEBI:24431
 
 relations:

--- a/src/patterns/dosdp-dev/abnormallyIncreasedResistanceOfWholeOrganismToEntity.yaml
+++ b/src/patterns/dosdp-dev/abnormallyIncreasedResistanceOfWholeOrganismToEntity.yaml
@@ -8,7 +8,7 @@ contributors:
 classes:
   increased resistance to: PATO:0001650
   abnormal: PATO:0000460
-  cellular organism: CARO:0010004
+  cellular organism: UBERON:0000468
   entity: BFO:0000001
 
 relations:


### PR DESCRIPTION
As we face out the use of CARO, we need to update the corresponding patterns from CARO: cellular organism to the UBERON: multicellular organism for "whole organism" patterns.