### PR TITLE
Update the EQ in abnormalLevelOfChemicalEntity

### DIFF
--- a/src/patterns/dosdp-patterns/abnormalLevelOfChemicalEntity.yaml
+++ b/src/patterns/dosdp-patterns/abnormalLevelOfChemicalEntity.yaml
@@ -1,29 +1,34 @@
 pattern_name: abnormalLevelOfChemicalEntity
 pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns/abnormalLevelOfChemicalEntity.yaml
-description: "An abnormal amount of a chemical or protein. For example, MP_0011230 'abnormal folic acid level or HP:0012146 Abnormality of von Willebrand factor.'"
+description: "An abnormal amount of a chemical or protein that is part of an
+              organism. For example, MP_0011230 'abnormal folic acid level or
+              HP:0012146 Abnormality of von Willebrand factor.'"
 
 contributors:
-  - https://orcid.org/0000-0003-4606-0597
-  - https://orcid.org/0000-0002-9900-7880
-  - https://orcid.org/0000-0002-3528-5267
-  - https://orcid.org/0000-0001-5208-3432
-  - https://orcid.org/0000-0003-4148-4606
-  - https://orcid.org/0000-0001-7941-2961
-  - https://orcid.org/0000-0002-7356-1779
-  - https://orcid.org/0000-0001-9076-6015
+  - https://orcid.org/0000-0003-4606-0597  # Susan Bello
+  - https://orcid.org/0000-0002-9900-7880  # Yvonne M. Bradford
+  - https://orcid.org/0000-0002-3528-5267  # Sofia Robb
+  - https://orcid.org/0000-0001-5208-3432  # Nicole Vasilevsky
+  - https://orcid.org/0000-0003-4148-4606  # Midori A. Harris
+  - https://orcid.org/0000-0001-7941-2961  # Leigh Carmody
+  - https://orcid.org/0000-0002-7356-1779  # Nicolas Matentzoglu
+  - https://orcid.org/0000-0001-9076-6015  # Christian A. Grove
+  - https://orcid.org/0000-0001-8314-2140  # Ray Stefancsik
 
 classes:
   amount: PATO:0000070
   abnormal: PATO:0000460
   chemical entity: CHEBI:24431
+  anatomical_entity: UBERON:0001062
 
 relations:
-  inheres_in: RO:0000052
+  characteristic_of: RO:0000052
   has_modifier: RO:0002573
   has_part: BFO:0000051
+  part_of: BFO:0000050
 
 annotationProperties:
-  exact_synonym: oio:hasExactSynonym 
+  exact_synonym: oio:hasExactSynonym
 
 vars:
   chemical_entity: "'chemical entity'"
@@ -31,7 +36,7 @@ vars:
 name:
   text: "abnormal %s level"
   vars:
-   - chemical_entity
+    - chemical_entity
 
 
 def:
@@ -40,7 +45,9 @@ def:
     - chemical_entity
 
 equivalentTo:
-  text: "'has_part' some ('amount' and ('inheres_in' some %s) and ('has_modifier' some 'abnormal'))"
+  text: "'has_part' some 'amount'
+            and ('characteristic_of' some (%s
+              and ('part_of' some 'anatomical_entity')))
+            and ('has_modifier' some 'abnormal')"
   vars:
     - chemical_entity
-


### PR DESCRIPTION
This commit intends to restrict the scope of the abnormalLevelOfChemicalEntity pattern to apply to chemical qualities only in anatomical entities. To achieve this, the logical definition will be updated.

If applied, this commit will fix #981.