### PR TITLE
Replace chebi slim URL

### DIFF
--- a/docs/odk-workflows/RepositoryFileStructure.md
+++ b/docs/odk-workflows/RepositoryFileStructure.md
@@ -24,7 +24,7 @@ These are the current imports in UPHENO
 | mpath | http://purl.obolibrary.org/obo/mpath.owl | None |
 | ro | http://purl.obolibrary.org/obo/ro.owl | None |
 | omo | http://purl.obolibrary.org/obo/omo.owl | None |
-| chebi | https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl | None |
+| chebi | http://purl.obolibrary.org/obo/upheno/chebi_slim.owl | None |
 | oba | http://purl.obolibrary.org/obo/oba.owl | None |
 | ncbitaxon | http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl | None |
 | pr | https://raw.githubusercontent.com/obophenotype/pro_obo_slim/master/pr_slim.owl | None |

--- a/src/curation/upheno-config.yaml
+++ b/src/curation/upheno-config.yaml
@@ -88,7 +88,7 @@ sources:
   - id: ro
     mirror_from: http://purl.obolibrary.org/obo/ro.owl
   - id: chebi
-    mirror_from: https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl
+    mirror_from: http://purl.obolibrary.org/obo/upheno/chebi_slim.owl
   - id: hsapdv
     mirror_from: http://purl.obolibrary.org/obo/hsapdv.owl
   - id: pato

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                076964339ab1c8c0df6a530dd04a9d5601405f8c5676db316523d5f47aae39b8
+CONFIG_HASH=                544a774a0dcd5628bbc267a18a49a7efbd6b4d59f72fce5847cc328adda6ac66
 
 
 # ----------------------------------------
@@ -686,7 +686,7 @@ mirror-ro: | $(TMPDIR)
 .PHONY: mirror-chebi
 .PRECIOUS: $(MIRRORDIR)/chebi.owl
 mirror-chebi: | $(TMPDIR)
-	$(ROBOT) remove -I https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl --base-iri http://purl.obolibrary.org/obo/CHEBI  --axioms external --preserve-structure false --trim false -o $(TMPDIR)/$@.owl
+	$(ROBOT) remove -I http://purl.obolibrary.org/obo/upheno/chebi_slim.owl --base-iri http://purl.obolibrary.org/obo/CHEBI  --axioms external --preserve-structure false --trim false -o $(TMPDIR)/$@.owl
 
 
 ## ONTOLOGY: hsapdv

--- a/src/ontology/upheno-odk.yaml
+++ b/src/ontology/upheno-odk.yaml
@@ -373,7 +373,7 @@ import_group:
       use_base: TRUE
     - id: chebi
       make_base: TRUE
-      mirror_from: https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl
+      mirror_from: http://purl.obolibrary.org/obo/upheno/chebi_slim.owl
     - id: hsapdv
       make_base: TRUE
       base_iris:


### PR DESCRIPTION
Replace https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl with http://purl.obolibrary.org/obo/upheno/chebi_slim.owl
Running update_repo updated makefile, but not docs/odk-workflows/RepositoryFileStructure.md and src/curation/upheno-config.yaml, so I have updated manually